### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Centry is a panic button intended to protect users against [Cold Boot Attacks](h
 * Compatable with Linux and Mac OS; with significantly more security in Linux.
 
 ## Installation ##
-####Linux####
+#### Linux ####
 For significantly improved security install the `secure-delete` package. On Ubuntu/Debian:
 
      sudo apt-get install secure-delete


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
